### PR TITLE
clarify community badge procedures, closes #1

### DIFF
--- a/syllabus/badge_calc.md
+++ b/syllabus/badge_calc.md
@@ -12,7 +12,7 @@ kernelspec:
   name: python3
 ---
 
-# Badge Calculations 
+# Detailed Grade Calculations 
 
 ```{important} 
 This page is generated with code and calculations, you can view them for more precise implementations of what the english sentences mean. 

--- a/syllabus/badges.md
+++ b/syllabus/badges.md
@@ -302,8 +302,8 @@ style earned fill:#2cf
 
 These are the instructions from your `community_contributions.md` file: 
 For each one: 
-- add an item in a bulleted list (start the line with `- ` )
-- create a link to your contribution like  `[text to display](url/of/contribution)``
+- In the community_contributions.md file on your kwl repo, add an item in a bulleted list (start the line with - )
+- Include a link to your contribution like `[text to display](url/of/contribution)`
 - create an individual pull request titled "Community-shortname" where `shortname` is a short name for what you did. approval on this PR by Dr. Brown will constitute credit for your grade
 - request a review on that PR from @brownsarahm
 

--- a/syllabus/badges.md
+++ b/syllabus/badges.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# Badge Visualizations 
+# Badge Procedures
 
 This page includes more visual versions of the information on the badge page.  You should read both, but this one is often more helpful, because some of the processes take a lot of words to explain and make more sense with a diagram for a lot of people. 
 
@@ -20,6 +20,7 @@ This page includes more visual versions of the information on the badge page.  Y
 ```{warning}
 This was changed substantively on 2023-09-08
 ```
+
 This is for a single example with specific dates, but it is similar for all future dates
 
 The columns (and purple boxes) correspond to branches in your KWL repo and the yellow boxes are the things that you have to do. The "critical" box is what you have to wait for us on. The arrows represent PRs (or a local merge for the first one)
@@ -294,5 +295,31 @@ style progress fill:#2cf
 style complete fill:#2cf
 style revision fill:#2cf
 style earned fill:#2cf
+
+```
+
+## Community Badges
+
+These are the instructions from your `community_contributions.md` file: 
+For each one: 
+- add an item in a bulleted list (start the line with `- ` )
+- create a link to your contribution like  `[text to display](url/of/contribution)``
+- create an individual pull request titled "Community-shortname" where `shortname` is a short name for what you did. approval on this PR by Dr. Brown will constitute credit for your grade
+- request a review on that PR from @brownsarahm
+
+```{important}
+You want one contribution per PR for tracking
+```
+
+```{mermaid}
+flowchart TD
+    contribute[Make a contribution <br> *typically not in your KWL*]
+    link[Add a link to your <br> contribution to your<br> communiyt_contribution.md<br> in your KWL repo]
+    pr[create a PR for that link]
+    rev[request a review <br> from @brownsarahm]
+    contribute --> link
+    link --> pr --> rev
+    rev --> approved[Dr. Brown approves] --> merge[Merge the PR]
+    merge --o earned
 
 ```

--- a/syllabus/grading.md
+++ b/syllabus/grading.md
@@ -284,7 +284,7 @@ You can earn community badges by:
 - sharing articles and discussing them in the course discussions 
 - contributing annotated resources the course website 
 
-You will maintain a list of your contributions in your KWL repo in the `community_contributions.md` file. All changes to this file should be submitted as a PR, with a review requested from @brownsarahm. 
+You will maintain a list of your contributions in your KWL repo in the `community_contributions.md` file. Every individual change to this file (representing one contribution) should be commited to a new branch and then submitted as a PR, with a review requested from @brownsarahm.
 
 ```{note}
 Some participation in your group repo and a small number of discussions will be required for experience, review, and practice badges. This means that not every single contribution or peer review to your team repo will earn a community badge. 

--- a/syllabus/grading.md
+++ b/syllabus/grading.md
@@ -131,7 +131,7 @@ For an A you must complete:
 
 
 You can also mix and match to get +/-. For example
-(all examples below assume 23 experience badges)
+(all examples below assume 22+ experience badges aand 13 lab checkouts)
 - A-: 18 practice + 4 explore
 - B+: 6 review + 12 practice +  4 explore
 - B-: 6 review + 12 practice 
@@ -149,7 +149,7 @@ These counts assume that the semester goes as planned and that there are 26 avai
 You cannot earn both practice and review badges for the same class session, but most practice badge requirements will include the review requirements plus some extra steps. 
 
 (integrative)=
-At the end of the semester, there will be special *integrative* badge opportunities that have multipliers attached to them. These badges will count for more than one. For example an integrative 2x review badge counts as two review badges.  These badges will be more complex than regular badges and therefore count more.  
+In the second half of the semester, there will be special *integrative* badge opportunities that have multipliers attached to them. These badges will count for more than one. For example an integrative 2x review badge counts as two review badges.  These badges will be more complex than regular badges and therefore count more.  
 
 ```{admonition} Can you do any combination of badges?
 :class: checkin, dropdown
@@ -279,10 +279,12 @@ Community Badge values:
 
 
 You can earn community badges by: 
-- fixing small issues on the course website (during  only)
+- fixing small issues on the course website (during penalty free zone only)
 - contributing extra terms or reviews to your team repo 
 - sharing articles and discussing them in the course discussions 
 - contributing annotated resources the course website 
+
+You will maintain a list of your contributions in your KWL repo in the `community_contributions.md` file. All changes to this file should be submitted as a PR, with a review requested from @brownsarahm. 
 
 ```{note}
 Some participation in your group repo and a small number of discussions will be required for experience, review, and practice badges. This means that not every single contribution or peer review to your team repo will earn a community badge. 


### PR DESCRIPTION
- adds community badge procedures from kwl template file
- fixes a typo to lower experience badge requirement and clarify lab requirement in additional examples
- clarifies title on some pages to make information easier to find

@AymanBx Can you confirm this answers your question? 